### PR TITLE
switch to Posix-compatible email RE

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 /.stack-work/
 /test/hanon_mapping/
 /test/hello.txt.anon
+rabbits.txt
+rabbits.txt.anon

--- a/src/Mapper.hs
+++ b/src/Mapper.hs
@@ -38,7 +38,7 @@ regexHighlighter re groupIndex subject = map (!! groupIndex) (subject =~ re :: [
 
 -- |Highlight any x@x.x string
 emailHighlighter :: Highlighter
-emailHighlighter = regexHighlighter "[^[:space:]]+@[^[:space:]]+\.[^[:space:]]+" 0
+emailHighlighter = regexHighlighter "[^[:space:]]+@[^[:space:]]+\\.[^[:space:]]+" 0
 
 phoneNumberHighlighter :: Highlighter
 phoneNumberHighlighter = regexHighlighter "[+]?[0-9]{8,13}" 0

--- a/src/Mapper.hs
+++ b/src/Mapper.hs
@@ -38,7 +38,7 @@ regexHighlighter re groupIndex subject = map (!! groupIndex) (subject =~ re :: [
 
 -- |Highlight any x@x.x string
 emailHighlighter :: Highlighter
-emailHighlighter = regexHighlighter "\\S+@\\S+\\.\\S+" 0
+emailHighlighter = regexHighlighter "[^[:space:]]+@[^[:space:]]+\.[^[:space:]]+" 0
 
 phoneNumberHighlighter :: Highlighter
 phoneNumberHighlighter = regexHighlighter "[+]?[0-9]{8,13}" 0


### PR DESCRIPTION
TDFA is a Posix-based back end and needs `[^[:space:]]` to match non-space characters.